### PR TITLE
Sasha/historgram

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(libsrc procstat.c)
+set(libsrc procstat.c percentile.c)
 
 add_library(objlib OBJECT ${libsrc})
 set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/percentile.c
+++ b/src/percentile.c
@@ -1,0 +1,89 @@
+/*
+ *   BSD LICENSE
+ *
+ *   Copyright (C) 2016 LightBits Labs Ltd. - All Rights Reserved
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of LightBits Labs Ltd nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "percentile.h"
+#include <memory.h>
+#include <string.h>
+#include <assert.h>
+
+/*
+ * Given a number, return the index of the corresponding bucket in
+ * the structure tracking percentiles.
+ *
+ * (1) find the group (and error bits) that the value
+ * belongs to by looking at its MSB. (2) find the bucket number in the
+ * group by looking at the index bits.
+ *
+ */
+static unsigned int percentile_value_to_index(uint32_t val)
+{
+	unsigned int msb, error_bits, base, offset, idx;
+
+	/* Find MSB starting from bit 0 */
+	if (val == 0)
+		msb = 0;
+	else
+		msb = (sizeof(val)*8) - __builtin_clz(val) - 1;
+
+	/*
+	 * MSB <= (PROCSTAT_BUCKET_BITS-1), cannot be rounded off. Use
+	 * all bits of the sample as index
+	 */
+	if (msb <= PROCSTAT_BUCKET_BITS)
+		return (unsigned int)val;
+
+	/* Compute the number of error bits to discard*/
+	error_bits = msb - PROCSTAT_BUCKET_BITS;
+
+	/* Compute the number of buckets before the group */
+	base = (error_bits + 1) << PROCSTAT_BUCKET_BITS;
+
+	/*
+	 * Discard the error bits and apply the mask to find the
+	 * index for the buckets in the group
+	 */
+	offset = (PROCSTAT_BUCKET_VALUES - 1) & (val >> error_bits);
+
+	/* Make sure the index does not exceed (array size - 1) */
+	idx = (base + offset) < (PROCSTAT_PERCENTILE_ARR_NR - 1) ?
+		(base + offset) : (PROCSTAT_PERCENTILE_ARR_NR - 1);
+
+	return idx;
+}
+
+void procstat_hist_add_point(uint32_t *histogram, uint32_t value)
+{
+	unsigned int index = percentile_value_to_index(value);
+
+	++histogram[index];
+}

--- a/src/percentile.c
+++ b/src/percentile.c
@@ -81,9 +81,61 @@ static unsigned int percentile_value_to_index(uint32_t val)
 	return idx;
 }
 
+
+/*
+ * Convert the given index of the bucket array to the value
+ * represented by the bucket
+ */
+uint32_t procstat_percentile_idx_to_val(unsigned int idx)
+{
+	unsigned int error_bits, k, base;
+
+	assert(idx < PROCSTAT_PERCENTILE_ARR_NR);
+
+	/* MSB <= (FIO_IO_U_PLAT_BITS-1), cannot be rounded off. Use
+	 * all bits of the sample as index */
+	if (idx < (PROCSTAT_BUCKET_VALUES << 1))
+		return idx;
+
+	/* Find the group and compute the minimum value of that group */
+	error_bits = (idx >> PROCSTAT_BUCKET_BITS) - 1;
+	base = 1 << (error_bits + PROCSTAT_BUCKET_BITS);
+
+	/* Find its bucket number of the group */
+	k = idx % PROCSTAT_BUCKET_VALUES;
+
+	/* Return the mean of the range of the bucket */
+	return base + ((k + 0.5) * (1 << error_bits));
+}
+
+
 void procstat_hist_add_point(uint32_t *histogram, uint32_t value)
 {
 	unsigned int index = percentile_value_to_index(value);
 
 	++histogram[index];
+}
+
+void procstat_percentile_calculate(uint32_t *histogram,
+				   uint64_t samples_count,
+				   struct procstat_percentile_result *result,
+				   unsigned result_len)
+{
+	unsigned long num_points = 0;
+	unsigned int  i, j = 0;
+
+
+	for (i = 0; i < PROCSTAT_PERCENTILE_ARR_NR && j < result_len; ++i) {
+		num_points += histogram[i];
+
+		/* several percentiles might be anwered with same bucket*/
+		while (num_points >= result[j].fraction * samples_count) {
+			assert(result[j].fraction <= 1.0);
+			result[j].value = procstat_percentile_idx_to_val(i);
+
+			++j;
+			if (j == result_len)
+				break;
+		}
+	}
 }

--- a/src/percentile.h
+++ b/src/percentile.h
@@ -1,0 +1,109 @@
+/*
+ *   BSD LICENSE
+ *
+ *   Copyright (C) 2016 LightBits Labs Ltd. - All Rights Reserved
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of LightBits Labs Ltd nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/*
+ * This algorithm is based on the way that FIO calculates latency percentiles.
+ * Suppose the series varies from 0 to 999, the straightforward
+ * method is to keep an array of (999 + 1) buckets, in which a counter
+ * keeps the count of samples which fall in the bucket, e.g.,
+ * {[0],[1],...,[999]}. However this consumes a huge amount of space,
+ * and can be avoided if an approximation is acceptable.
+ *
+ * One such method is to let the range of the bucket to be greater
+ * than one. This method has low accuracy when the value is small. For
+ * example, let the buckets be {[0,99],[100,199],...,[900,999]}, and
+ * the represented value of each bucket be the mean of the range. Then
+ * a value 0 has an round-off error of 49.5. To improve on this, we
+ * use buckets with non-uniform ranges, while bounding the error of
+ * each bucket within a ratio of the sample value. A simple example
+ * would be when error_bound = 0.005, buckets are {
+ * {[0],[1],...,[99]}, {[100,101],[102,103],...,[198,199]},..,
+ * {[900,909],[910,919]...}  }. The total range is partitioned into
+ * groups with different ranges, then buckets with uniform ranges. An
+ * upper bound of the error is (range_of_bucket/2)/value_of_bucket
+ *
+ * For better efficiency, we implement this using base two. We group
+ * samples by their Most Significant Bit (MSB), extract the next M bit
+ * of them as an index within the group, and discard the rest of the
+ * bits.
+ *
+ * E.g., assume a sample 'x' whose MSB is bit n (starting from bit 0),
+ * and use M bit for indexing
+ *
+ *        | n |    M bits   | bit (n-M-1) ... bit 0 |
+ *
+ * Because x is at least 2^n, and bit 0 to bit (n-M-1) is at most
+ * (2^(n-M) - 1), discarding bit 0 to (n-M-1) makes the round-off
+ * error
+ *
+ *           2^(n-M)-1    2^(n-M)    1
+ *      e <= --------- <= ------- = ---
+ *             2^n          2^n     2^M
+ *
+ * Furthermore, we use "mean" of the range to represent the bucket,
+ * the error e can be lowered by half to 1 / 2^(M+1). By using M bits
+ * as the index, each group must contains 2^M buckets.
+ *
+ * E.g. Let M (PROCSTAT_BUCKET_BITS) be 6
+ *      Error bound is 1/2^(6+1) = 0.0078125 (< 1%)
+ *
+ *	Group	MSB	#discarded	range of		#buckets
+ *			error_bits	value
+ *	----------------------------------------------------------------
+ *	0*	0~5	0		[0,63]			64
+ *	1*	6	0		[64,127]		64
+ *	2	7	1		[128,255]		64
+ *	3	8	2		[256,511]		64
+ *	4	9	3		[512,1023]		64
+ *	...	...	...		[...,...]		...
+ *	18	23	17		[8838608,+inf]**	64
+ *
+ *  * Special cases: when n < (M-1) or when n == (M-1), in both cases,
+ *    the value cannot be rounded off. Use all bits of the sample as
+ *    index.
+ *
+ *  ** If a sample's MSB is greater than 23, it will be counted as 23.
+ */
+
+#include <stdint.h>
+#define PROCSTAT_BUCKET_BITS 6
+#define PROCSTAT_BUCKET_VALUES (1 << PROCSTAT_BUCKET_BITS)
+#define PROCSTAT_GROUP_NR 19
+#define PROCSTAT_PERCENTILE_ARR_NR (PROCSTAT_GROUP_NR * PROCSTAT_BUCKET_VALUES)
+
+
+ /**
+ * @brief adds @value point to @histogram of length at least @PROCSTAT_PERCENTILE_ARR_NR
+ */
+void procstat_hist_add_point(uint32_t *histogram, uint32_t value);

--- a/src/percentile.h
+++ b/src/percentile.h
@@ -103,7 +103,20 @@
 #define PROCSTAT_PERCENTILE_ARR_NR (PROCSTAT_GROUP_NR * PROCSTAT_BUCKET_VALUES)
 
 
- /**
+struct procstat_percentile_result {
+	float 	 fraction;
+	uint32_t value;
+};
+
+/**
  * @brief adds @value point to @histogram of length at least @PROCSTAT_PERCENTILE_ARR_NR
  */
 void procstat_hist_add_point(uint32_t *histogram, uint32_t value);
+
+/**
+ * @brief calculates percentiles on histogram
+ */
+void procstat_percentile_calculate(uint32_t *histogram,
+				   uint64_t samples_count,
+				   struct procstat_percentile_result *result,
+				   unsigned result_len);

--- a/src/procstat.c
+++ b/src/procstat.c
@@ -980,7 +980,7 @@ static ssize_t procstat_fmt_u32_percentiles(void *object, uint64_t arg, char *bu
 {
 	struct procstat_histogram_u32 *series = object;
 
-	procstat_percentile_calculate(series->histogram, series->count, series->percentile, series->npercentile);
+	series->compute_cb(series->histogram, series->count, series->percentile, series->npercentile);
 	return procstat_format_u32_decimal(&series->percentile[arg].value, 0, buffer, length, offset);
 }
 
@@ -1048,6 +1048,9 @@ int procstat_create_histogram_u32_series(struct procstat_context *context, struc
 		errno = error;
 		goto fail_remove_stat;
 	}
+
+	if (!series->compute_cb)
+		series->compute_cb = procstat_percentile_calculate;
 
 	for (i = 0; i < series->npercentile; ++i) {
 		char stat_name[100];

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -257,6 +257,7 @@ struct procstat_histogram_u32 {
 	int	 			  npercentile;
 	struct procstat_percentile_result percentile[MAX_SUPPORTED_PERCENTILE];
 	uint32_t 			  *histogram;
+	percentiles_calculator 		  compute_cb;
 };
 
 /**

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -47,22 +47,26 @@ struct procstat_item;
 /**
  * @brief: stats formatter method
  * @param object registered with statistics
+ * @param arg registered with statistics
  * @param buffer to format object to
  * @param lenght of buffer
  * @param offset to return from beginning of buffer. This can be ignored in case statistics string
  * is large > 4K
  */
-typedef ssize_t (*procstats_formatter)(void *object, char *buffer, size_t length, off_t offset);
+typedef ssize_t (*procstats_formatter)(void *object, uint64_t arg, char *buffer, size_t length, off_t offset);
+
 
 /**
  * @brief registration parameter for simple value statistics
  * @name of statistics
  * @bject to be passed to the formatter.
+ * @arg to be passed together with object to formatter
  * @fmt data formatter
  */
 struct procstat_simple_handle {
 	const char 	    *name;
 	void 	 	    *object;
+	uint64_t 	    arg;
 	procstats_formatter fmt;
 };
 
@@ -118,7 +122,7 @@ int procstat_create_simple(struct procstat_context *context,
 			   size_t descriptors_len);
 
 #define DEFINE_PROCSTAT_FORMATTER(__type, __fmt, __fmt_name)\
-static inline ssize_t procstat_format_ ## __type ##_## __fmt_name(void *object, char *buffer, size_t len, off_t offset)\
+static inline ssize_t procstat_format_ ## __type ##_## __fmt_name(void *object, uint64_t arg, char *buffer, size_t len, off_t offset)\
 {\
 	return snprintf(buffer, len, __fmt, *((__type *)object));\
 }\
@@ -141,7 +145,7 @@ DEFINE_PROCSTAT_FORMATTER(u32, "%x\n", hex);
 #define DEFINE_PROCSTAT_SIMPLE_ATTRIBUTE(__type)\
 static inline int procstat_create_ ## __type(struct procstat_context *context, struct procstat_item *parent, const char *name, __type *object)\
 {\
-	struct procstat_simple_handle descriptor = {name, object, procstat_format_ ## __type ## _decimal};\
+	struct procstat_simple_handle descriptor = {name, object, 0UL, procstat_format_ ## __type ## _decimal};\
 	\
 	return procstat_create_simple(context, parent, &descriptor, 1);\
 }\
@@ -154,11 +158,11 @@ DEFINE_PROCSTAT_SIMPLE_ATTRIBUTE(u64);
  * get function to fetch object value
  */
 #define DEFINE_PROCSTAT_CUSTOM_FORMATTER(name, getter_function, __type, __fmt)\
-static inline ssize_t procstat_format_ ## __type ##_## name(void *object, char *buffer, size_t length, off_t offset)\
+static inline ssize_t procstat_format_ ## __type ##_## name(void *object, uint64_t arg, char *buffer, size_t length, off_t offset)\
 {\
 	__type out;\
 	\
-	getter_function((__type *)object, &out);\
+	getter_function((__type *)object, arg, &out);\
 	return snprintf(buffer, length, __fmt, out);\
 }\
 

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -40,6 +40,7 @@
 #include <stddef.h>
 #include <unistd.h>
 #include <stdio.h>
+#include "percentile.h"
 
 struct procstat_context;
 struct procstat_item;
@@ -54,7 +55,6 @@ struct procstat_item;
  * is large > 4K
  */
 typedef ssize_t (*procstats_formatter)(void *object, uint64_t arg, char *buffer, size_t length, off_t offset);
-
 
 /**
  * @brief registration parameter for simple value statistics
@@ -240,6 +240,25 @@ struct procstat_series_u64 {
 	uint64_t aggregated_variance;
 };
 
+
+/**
+ * @brief callback to calculate histogram values
+ */
+typedef void (*percentiles_calculator)(uint32_t *histogram,
+					uint64_t samples_count,
+					struct procstat_percentile_result *result,
+					unsigned result_len);
+
+#define MAX_SUPPORTED_PERCENTILE 20
+struct procstat_histogram_u32 {
+	uint64_t 			  sum;
+	uint64_t 			  count;
+	uint64_t 			  last;
+	int	 			  npercentile;
+	struct procstat_percentile_result percentile[MAX_SUPPORTED_PERCENTILE];
+	uint32_t 			  *histogram;
+};
+
 /**
  * @brief create series statistics.
  */
@@ -271,5 +290,11 @@ void procstat_remove(struct procstat_context *context, struct procstat_item *ite
  */
 int procstat_remove_by_name(struct procstat_context *context, struct procstat_item *parent, const char *name);
 
+
+
+int procstat_create_histogram_u32_series(struct procstat_context *context, struct procstat_item *parent,
+					 const char *name, struct procstat_histogram_u32 *series);
+
+void procstat_histogram_u32_add_point(struct procstat_histogram_u32 *series, uint32_t value);
 
 #endif

--- a/test/test.c
+++ b/test/test.c
@@ -85,7 +85,7 @@ void inc_values_64(uint64_t *vals)
 }
 
 
-static void fetch_getter(uint16_t *object, uint16_t *out)
+static void fetch_getter(uint16_t *object, uint64_t arg, uint16_t *out)
 {
 	*out = *object;
 }
@@ -101,9 +101,9 @@ DEFINE_PROCSTAT_CUSTOM_FORMATTER(fetch, fetch_getter, uint16_t, "%u");
 static void create_multiple_simple_stats(struct procstat_item *root, uint32_t *value_32, uint64_t *value_64, uint16_t *val16)
 {
 	struct procstat_item *item;
-	struct procstat_simple_handle descriptors[] = {{"val_32", value_32, procstat_format_u32_decimal},
-						       {"val_64", value_64, procstat_format_u64_decimal},
-							"val_16", val16, procstat_format_uint16_t_fetch};
+	struct procstat_simple_handle descriptors[] = {{"val_32", value_32, 0, procstat_format_u32_decimal},
+						       {"val_64", value_64, 0, procstat_format_u64_decimal},
+							"val_16", val16, 0, procstat_format_uint16_t_fetch};
 	int error;
 
 	item = procstat_create_directory(context, root, "multiple-simple");


### PR DESCRIPTION
Adding histogram statistics  that allows approximate  statistical analysis on stream data.
This allows to calculate series distribution approximation on hotpath with very little processing. Algorithm 
is based on partitioning range of values into groups and bukets, reducing data series to those buckets and count instances. With carefully choosing buckets size we can lower "error" to less than 1%. This is the sacrifice that we make in order not to keep the whole dataset. 



